### PR TITLE
Implement simple in memory store

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -24,12 +24,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8d976903543e0c48546a91908f21588a680a8c8f984df9a5d69feccb2b2a211"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "core"
 version = "0.1.0"
 dependencies = [
  "async-trait",
  "futures",
+ "js-sys",
  "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test",
 ]
 
 [[package]]
@@ -128,6 +141,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-sys"
+version = "0.3.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca059e81d9486668f12d455a4ea6daa600bd408134cd17e3d3fb5a32d1f016f8"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,6 +233,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
+
+[[package]]
 name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,6 +287,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7866cab0aa01de1edf8b5d7936938a7e397ee50ce24119aef3e1eaa3b6171da"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -286,3 +326,37 @@ name = "wasm-bindgen-shared"
 version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d649a3145108d7d3fbcde896a468d1bd636791823c9921135218ad89be08307"
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34d1cdc8b98a557f24733d50a1199c4b0635e465eecba9c45b214544da197f64"
+dependencies = [
+ "console_error_panic_hook",
+ "js-sys",
+ "scoped-tls",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8fb9c67be7439ee8ab1b7db502a49c05e51e2835b66796c705134d9b8e1a585"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bf6ef87ad7ae8008e15a355ce696bed26012b7caa21605188cfd8214ab51e2d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -4,17 +4,15 @@ version = "0.1.0"
 authors = ["Maximilian Alexander <max@ditto.live>"]
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [lib]
 crate-type = ["cdylib", "staticlib"]
 
 [dependencies]
+js-sys = "0.3"
 futures = "0.3"
-async-trait = "0.1.41"
-wasm-bindgen = { version = "0.2", optional = true }
+async-trait = "0.1"
+wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
 
-[features]
-wasm = ["wasm-bindgen"]
-
-
+[dev-dependencies]
+wasm-bindgen-test = "0.3"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,13 +1,124 @@
 use async_trait::async_trait;
 
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_futures::*;
+
+use std::collections::HashMap;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use js_sys::Promise;
+
+// -----------------------------------------------------------------------------
+
 #[async_trait]
 pub trait Store {
     fn new(name: &str) -> Self;
-    
-    async fn get(&self, key: &str) -> Result<String, ()>;
-    async fn put(&self, key: &str, value: &str) -> Result<(), ()>;
-    
-    fn clear(&self);
+
+    async fn get(&self, key: &str) -> Result<Option<String>, ()>;
+    async fn put(&mut self, key: &str, value: &str) -> Result<(), ()>;
+
+    fn clear(&mut self);
 }
 
+// -----------------------------------------------------------------------------
 
+#[derive(Debug)]
+pub struct InMemoryStore {
+    entries: HashMap<String, String>,
+}
+
+#[async_trait]
+impl Store for InMemoryStore {
+    fn new(_name: &str) -> Self {
+        // TODO: use global hash table and reference the entries by name
+        // (so it can be "opened" later on, as with a real implementation
+        // persisting contents).
+        Self { entries: HashMap::new() }
+    }
+
+    async fn get(&self, key: &str) -> Result<Option<String>, ()> {
+        let result = self.entries.get(&key.to_string());
+        match result {
+            Some(value) => Ok(Some(value.to_string())),
+            None => Ok(None)
+        }
+    }
+
+    async fn put(&mut self, key: &str, value: &str) -> Result<(), ()> {
+        // TODO: delay a bit to simulate async.
+        self.entries.insert(key.to_string(), value.to_string());
+        Ok(())
+    }
+
+    fn clear(&mut self) {
+        // TODO: this should probably be async too.
+        self.entries.clear()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_example() {
+        // Nothing here yet, all good.
+    }
+}
+
+// -----------------------------------------------------------------------------
+
+#[wasm_bindgen]
+pub struct JSStore {
+    store: Rc<RefCell<InMemoryStore>>,
+}
+
+#[wasm_bindgen]
+impl JSStore {
+
+    #[wasm_bindgen(constructor)]
+    pub fn new(name: &str) -> JSStore {
+        let in_memory_store = InMemoryStore::new(name);
+        let in_memory_store_ref_celled = RefCell::new(in_memory_store);
+        let in_memory_store_reference_counted = Rc::new(in_memory_store_ref_celled);
+        Self { store: in_memory_store_reference_counted }
+    }
+
+    #[wasm_bindgen]
+    pub fn get(&self, key: &str) -> Promise {
+        let store = self.store.clone();
+        let key = key.to_string();
+        let future = async move {
+            let store = store.borrow();
+            let result = store.get(&key).await;
+            match result {
+                Ok(value) => Ok(JsValue::from(value)),
+                Err(_error) => Err(JsValue::undefined())
+            }
+        };
+        future_to_promise(future)
+    }
+
+    #[wasm_bindgen]
+    pub fn put(&self, key: &str, value: &str) -> Promise {
+        let store = self.store.clone();
+        let key = key.to_string();
+        let value = value.to_string();
+        let future = async move {
+            let mut store = store.borrow_mut();
+            let result = store.put(&key, &value).await;
+            match result {
+                Ok(_value) => Ok(JsValue::undefined()),
+                Err(_error) => Err(JsValue::undefined())
+            }
+        };
+        future_to_promise(future)
+    }
+
+    #[wasm_bindgen]
+    pub fn clear(&self) {
+        let mut store = self.store.borrow_mut();
+        store.clear();
+    }
+}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build-core-native": "cargo build --manifest-path ./core/Cargo.toml",
     "build-core-wasm": "wasm-pack build core",
     "build-core": "npm run build-core-native && npm run build-core-wasm",
-    "build-typescript": "tsc",
+    "build-typescript": "./node_modules/.bin/tsc",
     "clean": "rm -rf dist",
     "test": "jest"
   },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "@babel/preset-typescript": "^7.10.4",
     "@types/jest": "^26.0.14",
     "babel-jest": "^26.5.2",
-    "jest": "^26.5.3"
+    "jest": "^26.5.3",
+    "typescript": "^4.0.3"
   },
   "scripts": {
     "build-core-native": "cargo build --manifest-path ./core/Cargo.toml",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4248,6 +4248,11 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
+typescript@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.3.tgz#153bbd468ef07725c1df9c77e8b453f8d36abba5"
+  integrity sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==
+
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz#2619800c4c825800efdd8343af7dd9933cbe2818"


### PR DESCRIPTION
Related issue: https://github.com/getditto/cross-platform-rust-js-boilerplate/issues/1

Very simple in-memory implementation for the `Store` trait plus a JS shim. `IndexedDB` implementation follows in a follow-up PR.